### PR TITLE
Lustre version 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Version 0.1.4-beta
+
+- Add forgotten "include" key word + add Lustre V6 "map" operator
+- Changed "function", "var" and "const" from keywords to storage type
+- Added "node" to the list of storage type. Altough is was already treated as a storage type.
+
 ## Version 0.1.3-beta
 
 - Add Open VSX deployment

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Lustre",
     "description": "Lustre syntax highlighting and snippets",
     "publisher" : "MercierCorentin",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "icon" : "images/logo.png",
     "readme": "README.md",
     "author": {

--- a/syntaxes/lustre.tmLanguage.json
+++ b/syntaxes/lustre.tmLanguage.json
@@ -158,15 +158,11 @@
             "patterns": [
                 {
                     "name": "keyword.control.lustre",
-                    "match": "\\b(if|then|else|assert|pre|current|when|fby)\\b"
+                    "match": "\\b(if|then|else|assert|pre|current|when|fby|include)\\b"
                 },
                 {
                     "name": "keyword.operator.lustre",
-                    "match": "\\b(>=|<=|=>|<>|<|>|=|-|\\^|and|or|not|xor|div|mod|nor)\\b"
-                },
-                {
-                    "name": "keyword.other.lustre",
-                    "match": "^\\s*(var|const)\\s+"
+                    "match": "\\b(>=|<=|=>|<>|<|>|=|\\-|\\+|\\*|\\/|\\^|and|or|not|xor|div|mod|nor|map)\\b"
                 }
             ]
         },
@@ -174,7 +170,7 @@
             "patterns": [
                 {
                     "name": "storage.type.lustre",
-                    "match": "\\b(int|real|bool|enum|struct)\\b"
+                    "match": "\\b(int|real|bool|enum|struct|function|node|var|const)\\b"
                 }
             ]
         },


### PR DESCRIPTION
- Add forgotten "include" key word + add Lustre V6 "map" operator
- Changed "function", "var" and "const" from keywords to storage type
- Added "node" to the list of storage type. Altough is was already treated as a storage type.