### PR TITLE
Improve syntax highlighting for comments.

### DIFF
--- a/syntaxes/lustre.tmLanguage.json
+++ b/syntaxes/lustre.tmLanguage.json
@@ -87,6 +87,9 @@
             "patterns": [
                 {
                     "include": "#varDecl"
+                },
+                {
+                    "include": "#comments"
                 }
             ],
             "end": "\\)"
@@ -101,6 +104,9 @@
             "patterns": [
                 {
                     "include": "#varDecl"
+                },
+                {
+                    "include": "#comments"
                 }
             ],
             "end": "\\)\\s*;?\\s*$"
@@ -385,6 +391,9 @@
                 },
                 {
                     "include": "#keywords"
+                },
+                {
+                    "include": "#comments"
                 },
                 {
                     "match": "(^|(?<=\\W))(\\w+)(\\.(\\w+))?(?=(\\W|$))(?!\\()",


### PR DESCRIPTION
Comments inside of expressions and inside the formal parameter lists for
nodes are now highlighted correctly.